### PR TITLE
Fix activity overlap lookups and I18n day translation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
   end
 
   def next_n_days(amount, day_of_week)
-    day = I18n.t(:"activerecord.attributes.activity.day_number.#{day_of_week}", day_of_week)
+    day = I18n.t("activerecord.attributes.activity.day_number.#{day_of_week}")
     (Date.today...Date.today + 7 * amount).select do |d|
       d.wday == day
     end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -43,8 +43,7 @@ class Activity < ActiveRecord::Base
 
   # Getting next n dates of day_of_week
   def next_n_days(n = 2)
-    day = I18n.t(:"activerecord.attributes.activity.day_number.#{day_of_week}",
-    day_of_week)
+    day = I18n.t("activerecord.attributes.activity.day_number.#{day_of_week}")
     (Date.today...Date.today + 7 * n).select do |d|
       d.wday == day
     end

--- a/app/models/individual_training.rb
+++ b/app/models/individual_training.rb
@@ -93,7 +93,7 @@ class IndividualTraining < ActiveRecord::Base
       end
       client.activities_people.where(date: date_of_training)
                               .where(person_id: client_id).each do |ca|
-        activity.where(activity_id: ca.id).each do |a|
+        Activity.where(id: ca.activity_id).each do |a|
           if (start_on...end_on).overlaps?(a.start_on...a.end_on)
             errors.add(:base, 'Masz w tym czasie zajęcie grupowe.')
           end

--- a/app/models/work_schedule.rb
+++ b/app/models/work_schedule.rb
@@ -54,8 +54,7 @@ class WorkSchedule < ActiveRecord::Base
   end
 
   def next_n_days(amount, day_of_week)
-    day = I18n.t(:"activerecord.attributes.activity.day_number.#{day_of_week}",
-                 day_of_week)
+    day = I18n.t("activerecord.attributes.activity.day_number.#{day_of_week}")
     (Date.today...Date.today + 7 * amount).select do |d|
       d.wday == day
     end


### PR DESCRIPTION
## Summary
- fix lookup for activities in client free time validation
- correct day translation for next_n_days methods

## Testing
- `bundle exec rake test` *(fails: Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68414a8fcfa48329adcb84448fca83da