### PR TITLE
Fix changelog typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ rails s
   * Naprawienie żle wyświetlających się podstron
   * Dodanie notatek informacyjnych na każdej podstronie
   * Wyświetlanie tylko najbliższych terminów zajęć grupowych
-  * Usunięty zielony haczyk pszy pustych opisach cen biletów/karnetów
+  * Usunięty zielony haczyk przy pustych opisach cen biletów/karnetów
   * Wyrównane wysokości bloków z cenami
   * Poprawienie wyglądu komentarza
   * Sortowane kolumny w activities/requests


### PR DESCRIPTION
## Summary
- correct a misspelling in README changelog

## Testing
- `bundle exec rake -T` *(fails: Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68414baa89748329a9ea31bc4fabef53