### PR TITLE
Add presence validation specs for BoughtDetail

### DIFF
--- a/spec/models/bought_detail_spec.rb
+++ b/spec/models/bought_detail_spec.rb
@@ -24,5 +24,9 @@ describe BoughtDetail, 'column specifications' do
 end
 
 describe BoughtDetail, 'validations' do
-
+  it { is_expected.to validate_presence_of :bought_data }
+  it { is_expected.to validate_presence_of :cost }
+  it { is_expected.to validate_presence_of :days }
+  it { is_expected.to validate_presence_of :entry_type_id }
+  it { is_expected.to validate_presence_of :person_id }
 end


### PR DESCRIPTION
## Summary
- add missing validation expectations for BoughtDetail model

## Testing
- `bundle exec rake spec SPEC=spec/models/bought_detail_spec.rb` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 2.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68414bc9def08329b22e1609a5ad2849