### PR TITLE
Update database cleaner comment

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -7,8 +7,8 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
-  # When testing multiple db connections transaction doesn't because it isolate
-  # connections from each other. See database_cleaner README for more info
+  # When testing multiple DB connections, `:transaction` doesn't work because it
+  # isolates connections from each other. See database_cleaner README for more info
   config.before(:each, multiple_db: true) do
     DatabaseCleaner.strategy = :truncation
   end


### PR DESCRIPTION
## Summary
- tweak comment wording in `spec/support/database_cleaner.rb`

## Testing
- `bundle exec rake spec` *(fails: Gemfile requires Ruby 2.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68414bc439c08329aaddbf0808b29ef6