### PR TITLE
Add missing unit tests

### DIFF
--- a/spec/factories/bought_details.rb
+++ b/spec/factories/bought_details.rb
@@ -1,13 +1,9 @@
-# == Schema Information
-#
-# Table name: bought_details
-#
-#  id            :integer          not null, primary key
-#  bought_data   :datetime         not null
-#  start_on      :date
-#  end_on        :date             not null
-#  entry_type_id :integer          not null
-#  person_id     :integer          not null
-#  cost          :decimal(5, 2)    not null
-#
-
+FactoryGirl.define do
+  factory :bought_detail do
+    association :entry_type
+    association :person, factory: :client
+    cost 50.0
+    days 7
+    start_on { Date.today }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :comment do
+    body 'Świetny wpis.'
+    association :person, factory: :client
+    association :news
+  end
+end

--- a/spec/factories/entry_types.rb
+++ b/spec/factories/entry_types.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :entry_type do
+    kind 'Bilet'
+    kind_details 'Normalny'
+    description 'Jednorazowy bilet'
+    price 12.5
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :like do
+    like true
+    association :person, factory: :client
+    association :news
+  end
+end

--- a/spec/factories/news.rb
+++ b/spec/factories/news.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :news do
+    title 'Nowy wpis'
+    content 'Długi opis wpisu'
+    scope 'public'
+    association :person, factory: :trainer
+  end
+end

--- a/spec/factories/vacations.rb
+++ b/spec/factories/vacations.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :vacation do
+    start_at { Date.today + 1 }
+    end_at { Date.today + 5 }
+    association :person, factory: :trainer
+  end
+end

--- a/spec/models/bought_detail_spec.rb
+++ b/spec/models/bought_detail_spec.rb
@@ -30,3 +30,15 @@ describe BoughtDetail, 'validations' do
   it { is_expected.to validate_presence_of :entry_type_id }
   it { is_expected.to validate_presence_of :person_id }
 end
+
+describe BoughtDetail, '#active?' do
+  it 'returns true when current date is within range' do
+    bd = build(:bought_detail, start_on: Date.today - 1, days: 10)
+    expect(bd.active?).to be_truthy
+  end
+
+  it 'returns false when current date is outside range' do
+    bd = build(:bought_detail, start_on: Date.today - 10, days: 5)
+    expect(bd.active?).to be_falsey
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Comment, 'associations' do
+  it { is_expected.to belong_to :person }
+  it { is_expected.to belong_to :news }
+end
+
+describe Comment, 'validations' do
+  it { is_expected.to validate_presence_of :body }
+  it { is_expected.to validate_length_of(:body).is_at_least(5).is_at_most(500) }
+end

--- a/spec/models/entry_type_spec.rb
+++ b/spec/models/entry_type_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe EntryType, 'associations' do
+  it { is_expected.to have_many :bought_details }
+end
+
+describe EntryType, 'validations' do
+  subject { build(:entry_type) }
+  it { is_expected.to validate_presence_of :kind }
+  it { is_expected.to validate_presence_of :kind_details }
+  it { is_expected.to validate_length_of(:kind_details).is_at_least(3) }
+  it { is_expected.to validate_presence_of :price }
+  it { is_expected.to validate_numericality_of(:price).is_greater_than(0).is_less_than(999) }
+end
+
+describe EntryType, 'scopes' do
+  let!(:ticket) { create(:entry_type, kind: 'Bilet') }
+  let!(:pass) { create(:entry_type, kind: 'Karnet') }
+
+  it 'returns tickets' do
+    expect(EntryType.tickets).to include(ticket)
+    expect(EntryType.tickets).not_to include(pass)
+  end
+
+  it 'returns passes' do
+    expect(EntryType.passes).to include(pass)
+    expect(EntryType.passes).not_to include(ticket)
+  end
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Like, 'associations' do
+  it { is_expected.to belong_to :person }
+  it { is_expected.to belong_to :news }
+end
+
+describe Like, 'validations' do
+  let!(:like) { create(:like) }
+
+  it 'requires unique person per news' do
+    duplicate = build(:like, person: like.person, news: like.news)
+    expect(duplicate.valid?).to be_falsey
+  end
+end

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe News, 'associations' do
+  it { is_expected.to belong_to :person }
+  it { is_expected.to have_many :likes }
+  it { is_expected.to have_many :comments }
+end
+
+describe News, 'validations' do
+  it { is_expected.to validate_presence_of :title }
+  it { is_expected.to validate_presence_of :content }
+  it { is_expected.to validate_presence_of :scope }
+end
+
+describe News, 'methods' do
+  let(:news) { create(:news) }
+  before do
+    create(:like, news: news, like: true)
+    create(:like, news: news, like: false)
+  end
+
+  it 'counts thumbs up' do
+    expect(news.thumbs_up_total).to eq 1
+  end
+
+  it 'counts thumbs down' do
+    expect(news.thumbs_down_total).to eq 1
+  end
+end

--- a/spec/models/vacation_spec.rb
+++ b/spec/models/vacation_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Vacation, 'associations' do
+  it { is_expected.to belong_to :person }
+end
+
+describe Vacation, 'validations' do
+  it { is_expected.to validate_presence_of :start_at }
+  it { is_expected.to validate_presence_of :end_at }
+  it { is_expected.to validate_presence_of :person_id }
+end
+
+describe Vacation, '#start_at_must_be_before_end_at' do
+  let(:vacation) { build(:vacation, start_at: Date.today + 5, end_at: Date.today + 1) }
+
+  it 'is invalid when start_at is after end_at' do
+    expect(vacation.valid?).to be_falsey
+  end
+end


### PR DESCRIPTION
## Summary
- add factories for entry types, comments, likes, news, vacations and bought details
- cover new models with specs
- test BoughtDetail `active?` logic

## Testing
- `bundle exec rspec` *(fails: command not found)*
- `bundle exec rake test` *(fails: Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68415402a77483298267b9c393651f6f