### PR TITLE
Fix trainer work schedule overlap validation

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -121,10 +121,8 @@ class Activity < ActiveRecord::Base
   # checks if new activity is while trainer works
   def overlapping_trainer_work_schedule
     work_schedules = WorkSchedule.where(person_id: person_id)
-    work_schedules.each do |ws|
-      unless (start_on...end_on).overlaps?(ws.start_time...ws.end_time)
-        errors.add(:base, 'W tym czasie trener nie pracuje.')
-      end
+    unless work_schedules.any? { |ws| (start_on...end_on).overlaps?(ws.start_time...ws.end_time) }
+      errors.add(:base, 'W tym czasie trener nie pracuje.')
     end
   end
 


### PR DESCRIPTION
## Summary
- simplify overlapping trainer work schedule validation

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 2.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b83f33638c8329b63523787bf2c479